### PR TITLE
Perform comprehensive wallet risk assessment

### DIFF
--- a/swarm/coordinator.jl
+++ b/swarm/coordinator.jl
@@ -65,6 +65,23 @@ const COORDINATOR_STATE = SwarmCoordinatorState(
 )
 
 """
+    swarm_task_to_dict(task::SwarmTask)::Dict
+Converts a SwarmTask struct to a dictionary for JSON serialization
+"""
+function swarm_task_to_dict(task::SwarmTask)::Dict
+    return Dict(
+        "task_id" => task.id,
+        "task_type" => task.task_type,
+        "wallet_address" => task.wallet_address,
+        "parameters" => task.parameters,
+        "priority" => task.priority,
+        "created_at" => string(task.created_at),
+        "assigned_worker" => task.assigned_worker,
+        "status" => task.status
+    )
+end
+
+"""
     start_swarm_coordinator()
 Starts the swarm coordinator
 """
@@ -361,14 +378,13 @@ function execute_task(task::SwarmTask, worker::SwarmWorker)
         execution_time = time() - start_time
         
         # Store result
-       # For completed tasks:
-       COORDINATOR_STATE.completed_tasks[task.id] = Dict(
-    "task" => swarm_task_to_dict(task), # <--- FIXED: Now stores a Dict
-    "result" => result,
-    "execution_time" => execution_time,
-    "worker_id" => worker.id,
-    "completed_at" => now()
-)
+        COORDINATOR_STATE.completed_tasks[task.id] = Dict(
+            "task" => swarm_task_to_dict(task),
+            "result" => result,
+            "execution_time" => execution_time,
+            "worker_id" => worker.id,
+            "completed_at" => now()
+        )
         
         # Update task status
         update_task_status(task.id, "COMPLETED")
@@ -383,14 +399,14 @@ function execute_task(task::SwarmTask, worker::SwarmWorker)
         
         log_error("Task $(task.id) failed: $e")
         
-     # For failed tasks:
-COORDINATOR_STATE.failed_tasks[task.id] = Dict(
-    "task" => swarm_task_to_dict(task), # <--- FIXED: Now stores a Dict
-    "error" => sprint(showerror, e),
-    "execution_time" => execution_time,
-    "worker_id" => worker.id,
-    "failed_at" => now()
-)
+        # Store failed task info
+        COORDINATOR_STATE.failed_tasks[task.id] = Dict(
+            "task" => swarm_task_to_dict(task),
+            "error" => sprint(showerror, e),
+            "execution_time" => execution_time,
+            "worker_id" => worker.id,
+            "failed_at" => now()
+        )
         
         # Update task status
         update_task_status(task.id, "FAILED")
@@ -540,35 +556,35 @@ end
     get_task_status(task_id::String)::Union{Dict, Nothing}
 Gets the status of a task
 """
-
 function get_task_status(task_id::String)::Union{Dict, Nothing}
-# Check completed tasks
-if haskey(COORDINATOR_STATE.completed_tasks, task_id)
-    return COORDINATOR_STATE.completed_tasks[task_id]
+    # Check completed tasks
+    if haskey(COORDINATOR_STATE.completed_tasks, task_id)
+        return COORDINATOR_STATE.completed_tasks[task_id]
+    end
+
+    # Check failed tasks
+    if haskey(COORDINATOR_STATE.failed_tasks, task_id)
+        return COORDINATOR_STATE.failed_tasks[task_id]
+    end
+
+    # Check pending/running/assigned tasks
+    task_index = findfirst(t -> t.id == task_id, COORDINATOR_STATE.task_queue)
+    if !isnothing(task_index)
+        task = COORDINATOR_STATE.task_queue[task_index]
+        return Dict(
+            "task_id" => task.id,
+            "task_type" => task.task_type,
+            "wallet_address" => task.wallet_address,
+            "priority" => task.priority,
+            "created_at" => string(task.created_at),
+            "assigned_worker" => task.assigned_worker,
+            "status" => task.status,
+            "parameters" => task.parameters
+        )
+    end
+    return nothing
 end
 
-# Check failed tasks
-if haskey(COORDINATOR_STATE.failed_tasks, task_id)
-    return COORDINATOR_STATE.failed_tasks[task_id]
-end
-
-# Check pending/running/assigned tasks
-task_index = findfirst(t -> t.id == task_id, COORDINATOR_STATE.task_queue)
-if !isnothing(task_index)
-    task = COORDINATOR_STATE.task_queue[task_index]
-    return Dict(
-        "task_id" => task.id,
-        "task_type" => task.task_type,
-        "wallet_address" => task.wallet_address,
-        "priority" => task.priority,
-        "created_at" => string(task.created_at),
-        "assigned_worker" => task.assigned_worker,
-        "status" => task.status,
-        "parameters" => task.parameters
-    )
-end
-return nothing
-end
 """
     get_swarm_status()::Dict
 Gets the current status of the swarm
@@ -588,19 +604,7 @@ function get_swarm_status()::Dict
     )
 end
 
-# Add this somewhere in SwarmCoordinator.jl, e.g., after the SwarmTask struct definition
-function swarm_task_to_dict(task::SwarmTask)::Dict
-    return Dict(
-        "task_id" => task.id,
-        "task_type" => task.task_type,
-        "wallet_address" => task.wallet_address,
-        "parameters" => task.parameters, # Assuming parameters is already Dict{String, Any}
-        "priority" => task.priority,
-        "created_at" => string(task.created_at), # Convert DateTime to String
-        "assigned_worker" => task.assigned_worker,
-        "status" => task.status
-    )
-end
+
 export get_task_status, start_swarm_coordinator, stop_swarm_coordinator, 
        submit_wallet_analysis_task, submit_token_analysis_task,
        submit_transaction_analysis_task, get_swarm_status


### PR DESCRIPTION
Fixes `MethodError` in `get_task_status` and improves `SwarmCoordinator` code structure.

The `MethodError` for `Main.SwarmCoordinator.get_task_status` was caused by incorrect indentation within the `get_task_status` function itself, preventing its proper definition. Additionally, the `swarm_task_to_dict` helper function was defined after its usage, which could lead to undefined behavior or errors. This PR corrects these structural issues, along with minor formatting improvements, to ensure reliable task status retrieval.