### PR TITLE
Fetch and display nft collection stats

### DIFF
--- a/backend/src/routes/predict.js
+++ b/backend/src/routes/predict.js
@@ -227,4 +227,36 @@ router.get('/stats', (req, res) => {
   }
 });
 
+/**
+ * GET /api/opensea-stats/:slug
+ * Fetch OpenSea stats for a given collection slug (dynamic)
+ */
+router.get('/opensea-stats/:slug', async (req, res) => {
+  const { slug } = req.params;
+  if (!slug) {
+    return res.status(400).json({
+      success: false,
+      message: 'Collection slug is required',
+      timestamp: new Date().toISOString()
+    });
+  }
+  try {
+    const stats = await nftService.fetchOpenSeaV2Stats(slug);
+    res.json({
+      success: true,
+      slug,
+      stats,
+      timestamp: new Date().toISOString()
+    });
+  } catch (error) {
+    console.error('OpenSea stats endpoint error:', error.message);
+    res.status(500).json({
+      success: false,
+      message: 'Failed to fetch OpenSea stats',
+      error: error.message,
+      timestamp: new Date().toISOString()
+    });
+  }
+});
+
 export default router;

--- a/backend/src/services/nftService.js
+++ b/backend/src/services/nftService.js
@@ -15,23 +15,21 @@ class NFTService {
   }
 
   /**
-   * Fetch collection data from OpenSea (free tier)
+   * Fetch collection data from OpenSea (now using v2 API for floor price and more)
    */
   async fetchOpenSeaData(collectionSlug) {
     try {
       const headers = {
         'Accept': 'application/json'
       };
-
       if (process.env.OPENSEA_API_KEY) {
         headers['X-API-KEY'] = process.env.OPENSEA_API_KEY;
       }
-
+      // Use v2 endpoint for stats
       const response = await axios.get(
-        `${this.openSeaBaseUrl}/collection/${collectionSlug}/stats`,
+        `https://api.opensea.io/api/v2/collections/${collectionSlug}/stats`,
         { headers, timeout: 10000 }
       );
-
       return response.data;
     } catch (error) {
       console.warn('OpenSea API error:', error.message);

--- a/backend/src/services/nftService.js
+++ b/backend/src/services/nftService.js
@@ -122,6 +122,7 @@ class NFTService {
   /**
    * Get collection metadata with fallbacks
    * Now tries Alchemy first, then OpenSea v2 for floor price and stats if Alchemy fails or is missing floor price.
+   * Pass collectionSlug if you want OpenSea fallback.
    */
   async getCollectionMetadata(contractAddress, collectionSlug = null) {
     const errors = [];

--- a/src/utils/api.ts
+++ b/src/utils/api.ts
@@ -49,6 +49,17 @@ export const nftApi = {
   async getProviders() {
     const response = await apiClient.get('/providers');
     return response.data;
+  },
+
+  // Fetch OpenSea stats by slug
+  async getOpenSeaStats(slug: string) {
+    try {
+      const response = await apiClient.get(`/opensea-stats/${slug}`);
+      return response.data;
+    } catch (error) {
+      // Error is already logged by interceptor
+      throw error;
+    }
   }
 };
 


### PR DESCRIPTION
Update NFT service to use OpenSea v2 API for dynamic collection stats, including floor price, and add a corresponding frontend interface.

The existing OpenSea v1 API lacked detailed collection statistics, specifically the floor price. This PR updates the `NFTService` to leverage the OpenSea v2 API for comprehensive stats and introduces a dynamic frontend interface for users to fetch these by collection slug. The `getCollectionMetadata` method also now uses OpenSea v2 as a fallback for floor price if Alchemy data is insufficient.

---

[Open in Web](https://www.cursor.com/agents?id=bc-d5ca75dd-cc54-4233-8376-f152ee6c1511) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-d5ca75dd-cc54-4233-8376-f152ee6c1511)